### PR TITLE
Adds RepoUrl to HighFpsPhysicsPlugin.json

### DIFF
--- a/SamplePlugin/HighFpsPhysicsPlugin.json
+++ b/SamplePlugin/HighFpsPhysicsPlugin.json
@@ -2,6 +2,7 @@
   "Author": "Kirrana",
   "Name": "High FPS Physics Fix",
   "Punchline": "Cuts the refresh rate of physics in half, \"fixing\" it at high fps.",
+  "RepoUrl": "https://github.com/Kirrana/xivlauncher_physics_plugin",
   "Description": "Causes the game's physics to work at higher FPS by making it update every second frame. \nToggle with /physics. \nMay cause excessive jiggling at lower FPS values. \nDisabling the entire plugin after turning on/off with /physics requires reboot to reenable.",
   "InternalName": "HighFpsPhysicsPlugin",
   "ApplicableVersion": "any",


### PR DESCRIPTION
This PR adds a RepoUrl to the JSON file so that you can get here by clicking a button in the Dalamud plugin installer.