### PR TITLE
Added support to update physics every 2-5 frames

### DIFF
--- a/SamplePlugin/Configuration.cs
+++ b/SamplePlugin/Configuration.cs
@@ -7,9 +7,35 @@ namespace HighFpsPhysicsPlugin;
 [Serializable]
 public class Configuration : IPluginConfiguration
 {
-    public int Version { get; set; } = 1;
+    public int Version { get; set; } = 2;
 
-    public int UpdatesToSkip = 2;
+    /// <summary>
+    /// Updates based on currently selected option in the UI combo box. See SkipUpdateOptionsList: <inheritdoc cref="SkipUpdateOptionsList"/>.
+    /// </summary>
+    public int FramesPerPhysicsUpdate
+    {
+        get
+        {
+            return SkipUpdateOptionsList[SkipUpdatesOptionsListSelectedIndex];
+        }
+    }
+
+    /// <summary>
+    /// The list provided for allowable numbers of frames to skip physics updates.
+    /// </summary>
+    public int[] SkipUpdateOptionsList = new int[]
+    {
+        2,
+        3,
+        4,  
+        5,
+    };
+
+    /// <summary>
+    /// Automatically modifies UpdatesToSkip based on the selected interface combo box.
+    /// </summary>
+    public int SkipUpdatesOptionsListSelectedIndex = 0;
+
     public bool EnableOnStartup = false;
 
     private DalamudPluginInterface? pluginInterface;

--- a/SamplePlugin/HighFpsPhysicsPlugin.csproj
+++ b/SamplePlugin/HighFpsPhysicsPlugin.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Authors>Kirrana</Authors>
     <Company></Company>
-    <Version>7.0.0</Version>
-    <Description>Simple plugin that cuts the physics' refresh rate in half, making physics (kinda) work at high (120) fps.</Description>
+    <Version>7.1.0</Version>
+    <Description>Simple plugin that divides the physics' refresh rate, making physics (kinda) work at high fps.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/Kirrana/xivlauncher_physics_plugin</PackageProjectUrl>
   </PropertyGroup>
@@ -17,6 +17,7 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!--TO BE DEPRECATED-->
 		<OutputPath>$(AppData)\XIVLauncher\devPlugins\HighFpsPhysicsPlugin\</OutputPath>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 	</PropertyGroup>
@@ -32,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.10" />
+    <PackageReference Include="DalamudPackager" Version="2.1.11" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
       <Private>false</Private>

--- a/SamplePlugin/Physics.cs
+++ b/SamplePlugin/Physics.cs
@@ -49,7 +49,7 @@ internal class Physics : IDisposable
 
     public void Enable()
     {
-        Service.Chat.Print($"Enabling Physics Modification.");
+        Service.Chat.Print("Enabling Physics Modification");
         physicsSkipHook?.Enable();
     }
 

--- a/SamplePlugin/Physics.cs
+++ b/SamplePlugin/Physics.cs
@@ -36,7 +36,7 @@ internal class Physics : IDisposable
     {
         callsSinceLastSkip += 1;
 
-        if (callsSinceLastSkip > Service.Settings.UpdatesToSkip)
+        if (callsSinceLastSkip > Service.Settings.FramesPerPhysicsUpdate)
         {
             callsSinceLastSkip = 0;
             return physicsSkipHook!.Original(a1, a2);
@@ -49,7 +49,7 @@ internal class Physics : IDisposable
 
     public void Enable()
     {
-        Service.Chat.Print("Enabling Physics Modification");
+        Service.Chat.Print($"Enabling Physics Modification.");
         physicsSkipHook?.Enable();
     }
 

--- a/SamplePlugin/PhysicsFix.cs
+++ b/SamplePlugin/PhysicsFix.cs
@@ -184,7 +184,7 @@ internal class PhysicsFix : IDisposable
 
     public void Enable()
     {
-        Chat.Print($"Enabling Physics Modification.");
+        Chat.Print("Enabling Physics Modification");
         oncePerFrameHook?.Enable();
         physFuncHook?.Enable();
     }

--- a/SamplePlugin/PhysicsFix.cs
+++ b/SamplePlugin/PhysicsFix.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Dalamud.Hooking;
 using Dalamud.Memory;
 using Dalamud.Utility.Signatures;
@@ -160,10 +159,8 @@ internal class PhysicsFix : IDisposable
         oncePerFrameHook?.Disable();
         physFuncHook?.Disable();
 
-        byte framesPerUpdate = (byte)(Service.Settings.FramesPerPhysicsUpdate);
-
         // change our add index to add the new amount next time counter hits 0
-        decVar[counterResetAddIndex] = framesPerUpdate;
+        decVar[counterResetAddIndex] = (byte)(Service.Settings.FramesPerPhysicsUpdate);
         MemoryHelper.WriteRaw(countHookMemAddr, decVar);
 
         oncePerFrameHook?.Enable();

--- a/SamplePlugin/PluginUI.cs
+++ b/SamplePlugin/PluginUI.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using Dalamud.Interface;
 using Dalamud.Interface.Windowing;
+using System.Linq;
 
 namespace HighFpsPhysicsPlugin;
 
@@ -15,8 +16,8 @@ internal class ConfigurationWindow : Window
     {
         SizeConstraints = new WindowSizeConstraints
         {
-            MinimumSize = new Vector2(275, 200),
-            MaximumSize = new Vector2(275,200)
+            MinimumSize = new Vector2(345, 230),
+            MaximumSize = new Vector2(345, 230)
         };
 
         Flags |= ImGuiWindowFlags.NoResize;
@@ -62,5 +63,24 @@ internal class ConfigurationWindow : Window
                 Service.PhysicsModification.Enable();
             }
         }
+
+        if (ImGui.Combo("FPS Divider Value",
+                        ref Service.Settings.SkipUpdatesOptionsListSelectedIndex,
+                        Service.Settings.SkipUpdateOptionsList.Select(x => $"1/{x}").ToArray(),
+                        Service.Settings.SkipUpdateOptionsList.Length))
+        {
+            Service.PhysicsModification.UpdateFramesToSkip();
+        }
+
+#if DEBUG
+        if (ImGui.Button("Print Debug", ImGuiHelpers.ScaledVector2(125.0f, 23.0f)))
+        {
+            Service.PhysicsModification.DebugMessage();
+        }
+        if (ImGui.Button("Print Counter", ImGuiHelpers.ScaledVector2(125.0f, 23.0f)))
+        {
+            Service.PhysicsModification.CounterDebugMessage();
+        }
+#endif
     }
 }

--- a/SamplePlugin/packages.lock.json
+++ b/SamplePlugin/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.10, )",
-        "resolved": "2.1.10",
-        "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
+        "requested": "[2.1.11, )",
+        "resolved": "2.1.11",
+        "contentHash": "9qlAWoRRTiL/geAvuwR/g6Bcbrd/bJJgVnB/RurBiyKs6srsP0bvpoo8IK+Eg8EA6jWeM6/YJWs66w4FIAzqPw=="
       }
     }
   }


### PR DESCRIPTION
Resolves https://github.com/Kirrana/xivlauncher_physics_plugin/issues/3
- Added a combo box to allow the user to select between 1/2 and 1/5 frame rate dividers
- Rearranged assembly in PhysicsFix.cs for readability (or, tried to)
- Added debugging info buttons when built in Debug mode

Fix was just implemented by keeping the TEST against 0xFFFFFFFF and just using a JNZ. Swapped the negation to a decrement.